### PR TITLE
OOZ2Mars Rover

### DIFF
--- a/OOZ2Mars Rover_LuisCorreia.md
+++ b/OOZ2Mars Rover_LuisCorreia.md
@@ -1,0 +1,27 @@
+OOZ2Mars Rover - Making of
+==========================
+
+* Speaker   : Luís Correia (optionally Basílio Vieira and Nuno Correia for moral support)
+* Available : all dates 
+* Length    : (at least) 30 mins
+* Language  : Portuguese
+
+Description
+-----------
+
+A lot of people have shown an interest in getting to know how our Mars Rover was made.
+We will explain the idea, concept and execution of our very fine Mars Rover that roamed the floors in Pavilhão do Conhecimento during Maker Faire 2015. 
+Blueprints (not really), code, mechanics and all other parts will be explained in under 30 minutes
+
+Speaker Bio
+-----------
+Legendary bicopter/tricopter builder, member of the fine One Over Zero community, mostly known as the "lobster crew"
+Co-creator of OOZLabs, a closed maker group that essentially makes things and stuff.
+
+Links
+-----
+
+* Blog: http://blog.loide.net
+* Company: http://labs.oneoverzero.org
+* Github: https://github.com/oozlabs / https://github.com/luisfcorreia
+* Contact: buga@loide.net


### PR DESCRIPTION
# OOZ2Mars Rover - Making of
- Speaker   : Luís Correia (optionally Basílio Vieira and Nuno Correia for moral support)
- Available : all dates 
- Length    : (at least) 30 mins
- Language  : Portuguese
## Description

A lot of people have shown an interest in getting to know how our Mars Rover was made.
We will explain the idea, concept and execution of our very fine Mars Rover that roamed the floors in Pavilhão do Conhecimento during Maker Faire 2015. 
Blueprints (not really), code, mechanics and all other parts will be explained in under 30 minutes
## Speaker Bio

Legendary bicopter/tricopter builder, member of the fine One Over Zero community, mostly known as the "lobster crew"
Co-creator of OOZLabs, a closed maker group that essentially makes things and stuff.
## Links
- Blog: http://blog.loide.net
- Company: http://labs.oneoverzero.org
- Github: https://github.com/oozlabs / https://github.com/luisfcorreia
- Contact: buga@loide.net
