### PR TITLE
Recognizing Content vs Pub in Live TV

### DIFF
--- a/content-vs-pub_alexandre-carvalho.md
+++ b/content-vs-pub_alexandre-carvalho.md
@@ -4,7 +4,7 @@ Content v.s. Pub - Live Video Processing Solution
 
 * Speaker   : Alexandre Carvalho
 * Available : anytime
-* Length    : 30 minutes
+* Length    : 60 minutes
 * Language  : English
 
 Description
@@ -24,7 +24,7 @@ Currently, back in telecom as a systems architect, defining systems, and produci
 Links
 -----
 
-* Company: http://http://nosinovacao.pt/
+* Company: http://nosinovacao.pt/
 * GitHub: https://github.com/ajscarvalho
 
 Extra Information

--- a/content-vs-pub_alexandre-carvalho.md
+++ b/content-vs-pub_alexandre-carvalho.md
@@ -1,0 +1,38 @@
+
+Content v.s. Pub - Live Video Processing Solution
+=========================
+
+* Speaker   : Alexandre Carvalho
+* Available : anytime
+* Length    : 30 minutes
+* Language  : English
+
+Description
+-----------
+
+I will present a video processing pipeline that is able to mark content boundaries in live tv streams. It means that it is able to distinguish between content and advertising, and able to realign EPG to some extent.
+The technologies involved are docker, kafka, python, ffmpeg, a tiny bit of openCV and a lot of Math.
+
+Speaker Bio
+-----------
+
+Started working in the telecom biz, creating a CRM from scratch in PHP.
+Later ingressed in SAPO to create the mobile versions of SAPO's products.
+Currently, back in telecom as a systems architect, defining systems, and producing some PoC's.
+
+
+Links
+-----
+
+* Company: http://http://nosinovacao.pt/
+* GitHub: https://github.com/ajscarvalho
+
+Extra Information
+-----------------
+
+Previous Talks: 
+* Multiplayer games with node.js
+* Mobile Maps
+* Python Pandas workshop
+
+


### PR DESCRIPTION
Content v.s. Pub - Live Video Processing Solution
=========================

* Speaker   : Alexandre Carvalho
* Available : anytime
* Length    : 60 minutes
* Language  : English

Description
-----------

I will present a video processing pipeline that is able to mark content boundaries in live tv streams. It means that it is able to distinguish between content and advertising, and able to realign EPG to some extent.
The technologies involved are docker, kafka, python, ffmpeg, a tiny bit of openCV and a lot of Math.

Speaker Bio
-----------

Started working in the telecom biz, creating a CRM from scratch in PHP.
Later ingressed in SAPO to create the mobile versions of SAPO's products.
Currently, back in telecom as a systems architect, defining systems, and producing some PoC's.


Links
-----

* Company: http://nosinovacao.pt/
* GitHub: https://github.com/ajscarvalho

Extra Information
-----------------

Previous Talks: 
* Multiplayer games with node.js
* Mobile Maps
* Python Pandas workshop

