### PR TITLE
Demystifying Accessibility: How to integrate an empathy-driven process in software teams.

### DIFF
--- a/demystifying-accessibility_rafaela-ferro.md
+++ b/demystifying-accessibility_rafaela-ferro.md
@@ -29,5 +29,5 @@ Extra Information
 -----------------
 
 I've given talks about accessibility at [Google DevFest Coimbra 2018](https://devfest.gdgcoimbra.xyz/) and 
-[The Zain Talks](https://www.meetup.com/zain-talks/). You can take a look at [my slides here](https://slides.com/anarafaelaferro/demystifying-accessbility/), 
+[The Zain Talks](https://www.meetup.com/zain-talks/). My previous slides are available [here](https://slides.com/anarafaelaferro/demystifying-accessbility/), 
 although I intend to focus more on the practical demos.

--- a/demystifying-accessibility_rafaela-ferro.md
+++ b/demystifying-accessibility_rafaela-ferro.md
@@ -1,0 +1,33 @@
+Demystifying Accessibility
+=========================
+
+* Speaker   : Rafaela Ferro
+* Available : All days
+* Length    : 60 minutes
+* Language  : English
+
+Description
+-----------
+
+How to stop viewing accessibility as an extra-mile, and start integrating an empathy-driven process in software teams.
+We'll start by analysing the responsability both designers and developers have in building inclusive software, and then
+go through practical examples on how to debug custom components and make them accessible.
+
+Speaker Bio
+-----------
+
+Designer and frontend developer building digital products for web and mobile.
+
+Links
+-----
+
+* Blog: https://www.rafaelaferro.com/index#blog
+* Company: https://deemaze.com
+* GitHub: https://github.com/anarafaelaferro
+
+Extra Information
+-----------------
+
+I've given talks about accessibility at [Google DevFest Coimbra 2018](https://devfest.gdgcoimbra.xyz/) and 
+[The Zain Talks](https://www.meetup.com/zain-talks/). You can take a look at [my slides here](https://slides.com/anarafaelaferro/demystifying-accessbility/), 
+although I intend to focus more on the practical demos.

--- a/demystifying-accessibility_rafaela-ferro.md
+++ b/demystifying-accessibility_rafaela-ferro.md
@@ -30,4 +30,4 @@ Extra Information
 
 I've given talks about accessibility at [Google DevFest Coimbra 2018](https://devfest.gdgcoimbra.xyz/) and 
 [The Zain Talks](https://www.meetup.com/zain-talks/). My previous slides are available [here](https://slides.com/anarafaelaferro/demystifying-accessbility/), 
-although I intend to focus more on the practical demos.
+however I intend to focus more on the practical demos.

--- a/demystifying-accessibility_rafaela-ferro.md
+++ b/demystifying-accessibility_rafaela-ferro.md
@@ -1,4 +1,4 @@
-Demystifying Accessibility
+Demystifying Accessibility: How to integrate an empathy-driven process in software teams.
 =========================
 
 * Speaker   : Rafaela Ferro


### PR DESCRIPTION
Demystifying Accessibility: How to integrate an empathy-driven process in software teams.
=========================

* Speaker   : Rafaela Ferro
* Available : All days
* Length    : 45 minutes + QA
* Language  : English

Description
-----------

How to stop viewing accessibility as an extra-mile, and start integrating an empathy-driven process in software teams.
We'll start by analysing the responsibility both designers and developers have in building inclusive software, and then go through practical examples on how to debug custom components and make them accessible.

Speaker Bio
-----------

Designer and frontend developer building digital products for web and mobile.

Links
-----

* Blog: https://www.rafaelaferro.com/index#blog
* Company: https://deemaze.com
* GitHub: https://github.com/anarafaelaferro

Extra Information
-----------------

I've given talks about accessibility at [Google DevFest Coimbra 2018](https://devfest.gdgcoimbra.xyz/) and 
[The Zain Talks](https://www.meetup.com/zain-talks/). My previous slides are available [here](https://slides.com/anarafaelaferro/demystifying-accessbility/), 
however I intend to focus more on the practical demos.