### PR TITLE
KDD: Kubernetes Driven Development

### DIFF
--- a/kubernetes-driven-development_ricardo-castro.md
+++ b/kubernetes-driven-development_ricardo-castro.md
@@ -1,0 +1,31 @@
+KDD: Kubernetes Driven Development
+=========================
+
+* Speaker   : Ricardo Castro
+* Available : All days
+* Length    : 45min + QA
+* Language  : English
+
+Description
+-----------
+
+Kubernetes is becoming the standard in container orchestration but tooling is still lagging behind more mature environments. While that’s true, the community has rallied behind this technology and has started to develop tools to help develop, manage and deploy Kubernetes ready applications. This talk aims to introduce tools like Telepresence to improve development by allowing easy interfacing with Kubernetes deployed services, Skaffold to automate builds and deploys and Helm to manage deploys. This talk will also live demo the development of an application and demonstrate all those tools at work.
+
+Speaker Bio
+-----------
+
+DevOps and Site Reliability Engineer at Uphold building highly performance, reliable and scalable systems. Strong believer in culture and teamwork. Open source passionate, taekwondo amateur and metal lover.
+
+Links
+-----
+
+* Blog: http://mccricardo.github.io/
+* Company: https://uphold.com/
+
+Extra Information
+-----------------
+
+Previous Talks:
+* [DevOpsDays Warsaw](https://devopsdays.pl/bio.html#id=35706)
+* [TugaIT](https://techinporto.com/archive/2018/speakers/ricardo-castro/)
+* [TechInPorto](https://tugait.pt/speakers/ricardo-castro/) 


### PR DESCRIPTION
KDD: Kubernetes Driven Development
=========================

* Speaker   : Ricardo Castro
* Available : All days
* Length    : 45min + QA
* Language  : English

Description
-----------

Kubernetes is becoming the standard in container orchestration but tooling is still lagging behind more mature environments. While that’s true, the community has rallied behind this technology and has started to develop tools to help develop, manage and deploy Kubernetes ready applications. This talk aims to introduce tools like Telepresence to improve development by allowing easy interfacing with Kubernetes deployed services, Skaffold to automate builds and deploys and Helm to manage deploys. This talk will also live demo the development of an application and demonstrate all those tools at work.

Speaker Bio
-----------

DevOps and Site Reliability Engineer at Uphold building highly performance, reliable and scalable systems. Strong believer in culture and teamwork. Open source passionate, taekwondo amateur and metal lover.

Links
-----

* Blog: http://mccricardo.github.io/
* Company: https://uphold.com/

Extra Information
-----------------

Previous Talks:
* [DevOpsDays Warsaw](https://devopsdays.pl/bio.html#id=35706)
* [TugaIT](https://techinporto.com/archive/2018/speakers/ricardo-castro/)
* [TechInPorto](https://tugait.pt/speakers/ricardo-castro/) 