### PR TITLE
Raising a unicorn

### DIFF
--- a/2019/raising-a-unicorn_raoul_felix.md
+++ b/2019/raising-a-unicorn_raoul_felix.md
@@ -1,0 +1,44 @@
+Raising a 🦄
+=========================
+
+* Speaker   : Raoul Felix
+* Available : 
+* Length    : 30 minutes
+* Language  : English
+
+Description
+-----------
+
+Growing a business from 2 founders to 500 people in 3 countries is anything but
+a straight line. Talkdesk’s employee no 1 and CTO describes the journey, the
+technical challenges and the organisational pivots that made the startup one of
+Portugal’s unicorns.
+
+Speaker Bio
+-----------
+
+![Speaker Image](https://avatars0.githubusercontent.com/u/9947?v=3&s=466)
+
+Raoul was Talkdesk's first hire and currently serves as the Talkdesk’s CTO.
+He's really passionate about software as a craft, on how to solve real problems with
+elegant code, using the right technologies that enable us be more productive
+while delivering more value.
+Raoul holds a M.S. in
+Distributed Systems and Software Engineering from the Instituto Superior
+Técnico of the University of Lisbon.'
+
+Links
+-----
+
+* Github: http://github.com/rfelix
+* Company: http://talkdesk.com
+
+Extra Information
+-----------------
+
+* Email: raoul talkdesk.com
+* Twitter: [@rfelix_com](https://twitter.com/rfelix_com) (open DMs)
+
+Click [here][1] to see the full calendar and pick your favorite talks
+
+[1]: https://pixels.camp/schedule/


### PR DESCRIPTION
Growing a business from 2 founders to 500 people in 3 countries is anything but
a straight line. Talkdesk’s employee no 1 and CTO describes the journey, the
technical challenges and the organisational pivots that made the startup one of
Portugal’s unicorns.