### PR TITLE
Boxing Apples: packaging for Darwin

### DIFF
--- a/boxing-apples_rodrigo-goncalves.md
+++ b/boxing-apples_rodrigo-goncalves.md
@@ -1,0 +1,33 @@
+Boxing Apples: packaging for Darwin
+=================================================
+
+* Speaker   : [Rodrigo Gonçalves](https://pixels.camp/pragmapilot)
+* Available : **27 March in the afternoon** 
+* Length    :  **60m**
+* Language  : **English** 
+
+Description
+-----------
+
+In this day and age of magical toolchains that abstract most of development steps do you know how your Darwin app is being packaged? Let's take a peek under the hood and see not just how it's done but let's also explore how we can manually prepare a packaged Darwin app written in Swift **without** using the Xcode or Swift Package Manager toolchains.  
+
+Speaker Bio
+-----------
+
+13y of experience Software Engineer turned into Engineering Manager. Past lives in iOS, Android, Web, APIs and desktop systems. INFJ, people lover, perpetual learner and true believer in the human ability of growing and improving.
+
+Links
+-----
+
+* Company: https://talkdesk.com 
+* GitHub: https://github.com/pragmapilot 
+* Photo: https://raw.githubusercontent.com/PixelsCamp/talks/master/img/rodrigo_goncalves.jpg 
+
+Extra Information
+-----------------
+
+In this talk I intend to cover the packaging process of Darwin (iOS/macOS) apps. I will discuss how the Darwin OS expects an app to be packed, focusing on the structure. Compilation and linkage need to be adjusted for the proper targets and to take into account if external frameworks are used in the application. 
+
+The challenge here is not to use the Xcode or Swift Package Manager but to build, throughout the presentation, a simple packaging system that resembles these toolchains in the basic functionality to explain how the package is done. While the core of the talk will focus on Mac app I will include a section describing how the solution can be adapted to iOS, thus explaining the difference between both targets
+
+I am currently working on a small sample command-line Mac app that will be the basis for the explanation. This is still a work-in-process and the repo will be made publicly available before the talk or sooner when it is in a less transient state.

--- a/boxing-apples_rodrigo-goncalves.md
+++ b/boxing-apples_rodrigo-goncalves.md
@@ -2,7 +2,7 @@ Boxing Apples: packaging for Darwin
 =================================================
 
 * Speaker   : [Rodrigo Gonçalves](https://pixels.camp/pragmapilot)
-* Available : **27 March in the afternoon** 
+* Available : **26 or 27 March in the afternoon** 
 * Length    :  **60m**
 * Language  : **English** 
 

--- a/boxing-apples_rodrigo-goncalves.md
+++ b/boxing-apples_rodrigo-goncalves.md
@@ -3,7 +3,7 @@ Boxing Apples: packaging for Darwin
 
 * Speaker   : [Rodrigo Gonçalves](https://pixels.camp/pragmapilot)
 * Available : **27 March in the afternoon** 
-* Length    :  **60m**
+* Length    :  **30m**
 * Language  : **English** 
 
 Description

--- a/boxing-apples_rodrigo-goncalves.md
+++ b/boxing-apples_rodrigo-goncalves.md
@@ -2,13 +2,8 @@ Boxing Apples: packaging for Darwin
 =================================================
 
 * Speaker   : [Rodrigo Gonçalves](https://pixels.camp/pragmapilot)
-<<<<<<< HEAD
 * Available : **27 March in the afternoon** 
 * Length    :  **30m**
-=======
-* Available : **26 or 27 March in the afternoon** 
-* Length    :  **60m**
->>>>>>> 19732024f9d21e0e65b549b8167b22385224f4b1
 * Language  : **English** 
 
 Description


### PR DESCRIPTION
- Speaker   : Rodrigo Gonçalves
- Available : 26 or 27 March in the afternoon slot
- Length    : 30m
- Language  : English

Description
-----------

In this day and age of magical toolchains that abstract most of development steps do you know how your Darwin app is being packaged? Let's take a peek under the hood and see not just how it's done but let's also explore how we can manually prepare a packaged Darwin app written in Swift without using the Xcode or Swift Package Manager toolchains.

Speaker Bio
------------

13y of experience Software Engineer turned into Engineering Manager. Past lives in iOS, Android, Web, APIs and desktop systems. INFJ, people lover, perpetual learner and true believer in the human ability of growing and improving.

Links
-----

- Company: https://talkdesk.com
- GitHub: https://github.com/pragmapilot
- Photo: https://raw.githubusercontent.com/PixelsCamp/talks/master/img/rodrigo_goncalves.jpg

Extra Information
------------------

In this talk I intend to cover the packaging process of Darwin (iOS/macOS) apps. I will discuss how the Darwin OS expects an app to be packed, focusing on the structure. Compilation and linkage need to be adjusted for the proper targets and to take into account if external frameworks are used in the application.

The challenge here is not to use the Xcode or Swift Package Manager but to build, throughout the presentation, a simple packaging system that resembles these toolchains in the basic functionality to explain how the package is done. While the core of the talk will focus on Mac app I will include a section describing how the solution can be adapted to iOS, thus explaining the difference between both targets

I am currently working on a small sample command-line Mac app that will be the basis for the explanation. This is still a work-in-process and the repo will be made publicly available before the talk or sooner when it is in a less transient state.