### PR TITLE
A trip down Docker build history to BuildKit

### DIFF
--- a/A-trip-down-Docker-build-history-to-BuildKit_Fernando_Miguel.md
+++ b/A-trip-down-Docker-build-history-to-BuildKit_Fernando_Miguel.md
@@ -11,6 +11,19 @@ Description
 
 The evolution of Docker Build engine, enabling and benefits of BuildKit and what BuildX can do for you.
 
+Did you know that the docker built engine is six years old and it had almost no changes in those six years?
+
+The last big change done to it was adding multi-stage builds and that was with Docker 17.05.
+
+Developers and users started asking for more features but the build engine is so complex that it was impossible to add anything else.
+
+Enter BuildKit.
+
+BuildKit is an entire new code base meant to replace the current moby build engine.
+
+
+
+
 Speaker Bio
 -----------
 

--- a/A-trip-down-Docker-build-history-to-BuildKit_Fernando_Miguel.md
+++ b/A-trip-down-Docker-build-history-to-BuildKit_Fernando_Miguel.md
@@ -1,0 +1,32 @@
+A trip down Docker build history to BuildKit
+=================================================
+
+* Speaker   : Fernando Miguel
+* Available : any
+* Length    : 30 min
+* Language  : English
+
+Description
+-----------
+
+The evolution of Docker Build engine, enabling and benefits of BuildKit and what BuildX can do for you.
+
+Speaker Bio
+-----------
+
+Fernando is a Solution Architect, DevSecOps, SRE. He’s an advocate of self-empowering others.
+
+Links
+-----
+
+* GitHub: https://github.com/FernandoMiguel/
+* Talk code: https://github.com/FernandoMiguel/BuildKit/
+* Talk slides: https://docs.google.com/presentation/d/1q371o-7zKgN8p9ZC7QySaAIWViweScl8WZLSD1KkabY/edit?usp=sharing
+* Twitter: https://twitter.com/BlnaryMlke/
+* Photo: https://photos.app.goo.gl/o8KLcKRvGGhNa25i6
+
+Extra Information
+-----------------
+
+This talk was previously done at Docker London Meetup, in the Cloudflare London offices
+https://www.meetup.com/Docker-London/events/258668741/


### PR DESCRIPTION
A trip down Docker build history to BuildKit
=================================================

* Speaker   : Fernando Miguel
* Available : any
* Length    : 30 min
* Language  : English

Description
-----------

The evolution of Docker Build engine, enabling and benefits of BuildKit and what BuildX can do for you.

Did you know that the docker built engine is six years old and it had almost no changes in those six years?

The last big change done to it was adding multi-stage builds and that was with Docker 17.05.

Developers and users started asking for more features but the build engine is so complex that it was impossible to add anything else.

Enter BuildKit.

BuildKit is an entire new code base meant to replace the current moby build engine.




Speaker Bio
-----------

Fernando is a Solution Architect, DevSecOps, SRE. He’s an advocate of self-empowering others.

Links
-----

* GitHub: https://github.com/FernandoMiguel/
* Talk code: https://github.com/FernandoMiguel/BuildKit/
* Talk slides: https://docs.google.com/presentation/d/1q371o-7zKgN8p9ZC7QySaAIWViweScl8WZLSD1KkabY/edit?usp=sharing
* Twitter: https://twitter.com/BlnaryMlke/
* Photo: https://photos.app.goo.gl/o8KLcKRvGGhNa25i6

Extra Information
-----------------

This talk was previously done at Docker London Meetup, in the Cloudflare London offices
https://www.meetup.com/Docker-London/events/258668741/