### PR TITLE
Paste Wars: fighting for copypaste freedom

### DIFF
--- a/paste-wars-fighting-for-copypaste-freedom_ignat-korchagin.md
+++ b/paste-wars-fighting-for-copypaste-freedom_ignat-korchagin.md
@@ -3,7 +3,7 @@ Paste Wars: fighting for copypaste freedom
 
 * Speaker   : **Ignat Korchagin**
 * Available : **any day**
-* Length    : **30 minutes**
+* Length    : **60 minutes**
 * Language  : **English**
 
 Description

--- a/paste-wars-fighting-for-copypaste-freedom_ignat-korchagin.md
+++ b/paste-wars-fighting-for-copypaste-freedom_ignat-korchagin.md
@@ -1,0 +1,47 @@
+Paste Wars: fighting for copypaste freedom
+=================================================
+
+* Speaker   : **Ignat Korchagin**
+* Available : **any day**
+* Length    : **30 minutes**
+* Language  : **English**
+
+Description
+-----------
+
+Tired of websites blocking password paste, so you can’t use your favourite password manager? Don’t want to install questionable and non-portable third-party browser plugins to unblock paste? Your operating system can help with this!
+
+Introducing a simple tool, which can type in complex passwords for you without accessing your browsing data and restore your right to paste!
+
+Speaker Bio
+-----------
+
+Ignat is a security engineer at Cloudflare working mostly on platform and hardware security. Ignat’s interests are cryptography, hacking, and low-level programming. Before Cloudflare, Ignat worked as a senior security engineer for Samsung Electronics’ Mobile Communications Division. His solutions may be found in many older Samsung smart phones and tablets. Ignat started his career as a security researcher in the Ukrainian government’s communications services.
+
+Links
+-----
+
+* Blog: https://pqsec.org/
+* Company: https://www.cloudflare.com/
+* GitHub: https://github.com/ignatk
+* Photo: https://hacktivity.com/wp-content/uploads/2019/07/ignat_profile-390x390.jpg
+
+Extra Information
+-----------------
+
+Extended abstract:
+
+No one knows where it came from, but it is spreading like a disease: blocking paste functionality on online password forms. There is no explanation, no research, just a typical “this is for your security…”. And yet, all this is in the age of almost defeating the threat of weak and reused passwords by adopting password managers.
+
+Some try to fight back: Firefox, for example, allows users to disable the block by completely turning off paste notifications. However, this is like cracking a nut with a sledgehammer, as there may be many other legitimate use-cases for sites to handle paste events.
+
+There are also some browser plugins: they go as far as scanning the whole DOM and removing the blocker code or injecting passwords directly into the page. But these come not without risks: unveiling passwords and full browsing history to third-party applications (which, by the way, have full network access). Also, users are limited in the choice of their browser, as these plugins are often not portable.
+
+It feels a bit wrong when a website (or anyone else) decides what users can or cannot do on their computers. However, there is hope: instead of fighting paste blockers, why not just provide the password in the “natural” way they expect—by typing it in. But the typing will be done by the user’s operating system, rather than the user himself: the OS can automatically type a very complex password from any password manager for you. And paste blockers can never block it—because this is the only way they should allow the password to get in, by design. These ‘Paste Wars’ are over: introducing a simple tool, which can type in complex passwords and restore users’ rights to paste!
+
+Some talks:
+
+* Go as a scripting language in Linux: https://youtu.be/k7oosn5HrKk
+* Live-Patching Weak Crypto with OpenSSL Engines: https://youtu.be/QJtiOhPEjtU
+* The Definitive Guide to Make Software Fail on ARM64: https://youtu.be/ZhIxQY-WwgQ
+* Exploiting USB/IP: https://youtu.be/EjYKF-xG_VY


### PR DESCRIPTION
Paste Wars: fighting for copypaste freedom
=================================================

* Speaker   : **Ignat Korchagin**
* Available : **any day**
* Length    : **60 minutes**
* Language  : **English**

Description
-----------

Tired of websites blocking password paste, so you can’t use your favourite password manager? Don’t want to install questionable and non-portable third-party browser plugins to unblock paste? Your operating system can help with this!

Introducing a simple tool, which can type in complex passwords for you without accessing your browsing data and restore your right to paste!

Speaker Bio
-----------

Ignat is a security engineer at Cloudflare working mostly on platform and hardware security. Ignat’s interests are cryptography, hacking, and low-level programming. Before Cloudflare, Ignat worked as a senior security engineer for Samsung Electronics’ Mobile Communications Division. His solutions may be found in many older Samsung smart phones and tablets. Ignat started his career as a security researcher in the Ukrainian government’s communications services.

Links
-----

* Blog: https://pqsec.org/
* Company: https://www.cloudflare.com/
* GitHub: https://github.com/ignatk
* Photo: https://hacktivity.com/wp-content/uploads/2019/07/ignat_profile-390x390.jpg

Extra Information
-----------------

Extended abstract:

No one knows where it came from, but it is spreading like a disease: blocking paste functionality on online password forms. There is no explanation, no research, just a typical “this is for your security…”. And yet, all this is in the age of almost defeating the threat of weak and reused passwords by adopting password managers.

Some try to fight back: Firefox, for example, allows users to disable the block by completely turning off paste notifications. However, this is like cracking a nut with a sledgehammer, as there may be many other legitimate use-cases for sites to handle paste events.

There are also some browser plugins: they go as far as scanning the whole DOM and removing the blocker code or injecting passwords directly into the page. But these come not without risks: unveiling passwords and full browsing history to third-party applications (which, by the way, have full network access). Also, users are limited in the choice of their browser, as these plugins are often not portable.

It feels a bit wrong when a website (or anyone else) decides what users can or cannot do on their computers. However, there is hope: instead of fighting paste blockers, why not just provide the password in the “natural” way they expect—by typing it in. But the typing will be done by the user’s operating system, rather than the user himself: the OS can automatically type a very complex password from any password manager for you. And paste blockers can never block it—because this is the only way they should allow the password to get in, by design. These ‘Paste Wars’ are over: introducing a simple tool, which can type in complex passwords and restore users’ rights to paste!

Some talks:

* Go as a scripting language in Linux: https://youtu.be/k7oosn5HrKk
* Live-Patching Weak Crypto with OpenSSL Engines: https://youtu.be/QJtiOhPEjtU
* The Definitive Guide to Make Software Fail on ARM64: https://youtu.be/ZhIxQY-WwgQ
* Exploiting USB/IP: https://youtu.be/EjYKF-xG_VY