### PR TITLE
Make your ZX Spectrum shine again

### DIFF
--- a/make-your-spectrum-shine-again_luis-correia
+++ b/make-your-spectrum-shine-again_luis-correia
@@ -1,0 +1,40 @@
+Make your ZX Spectrum shine again
+=========================
+
+* Speaker   : Luis Correia
+* Available : all days
+* Length    : 30 minutes
+* Language  : Portuguese
+
+Description
+-----------
+
+Fueled by last year's appearance of an actual ZX Spectrum, I've managed to get my units back to working condition
+
+In this short talk I'll explain what you need to do to your ageing hardware in order to make them work again. This is specific for the Speccy but most can be also used for C64 ans Atari ST machines.
+
+Emulators are fun, easy and convenient but nothing like the actual feel of that crappy rubber keys
+
+
+Speaker Bio
+-----------
+
+Legendary bicopter/tricopter builder, member of the fine One Over Zero community, mostly known as the "lobster crew"
+Co-creator of OOZLabs, a closed maker group that essentially makes things and stuff.
+
+Links
+-----
+
+* Blog: https://blog.loide.net
+* Company: https://labs.oneoverzero.org
+* Github: https://github.com/oozlabs / https://github.com/luisfcorreia
+* Photo: https://avatars3.githubusercontent.com/u/191885?v=3&s=400
+
+Extra Information
+-----------------
+
+This talk was a last minute shout out from my heart and it loosely relates to right to repair
+
+Past talks @ PixelsCamp 
+* https://github.com/PixelsCamp/talks/blob/master/2019/right-to-repair_luis-correia.md
+* https://github.com/PixelsCamp/talks/blob/master/2016/ooz2mars-rover_luis-correia.md

--- a/make-your-spectrum-shine-again_luis-correia
+++ b/make-your-spectrum-shine-again_luis-correia
@@ -3,7 +3,7 @@ Make your ZX Spectrum shine again
 
 * Speaker   : Luis Correia
 * Available : all days
-* Length    : 30 minutes
+* Length    : 45 minutes + Q&A
 * Language  : Portuguese
 
 Description
@@ -14,6 +14,8 @@ Fueled by last year's appearance of an actual ZX Spectrum, I've managed to get m
 In this short talk I'll explain what you need to do to your ageing hardware in order to make them work again. This is specific for the Speccy but most can be also used for C64 ans Atari ST machines.
 
 Emulators are fun, easy and convenient but nothing like the actual feel of that crappy rubber keys
+
+(if aprooved, it might summon actual ZX Spectrums, for science)
 
 
 Speaker Bio


### PR DESCRIPTION
Make your ZX Spectrum shine again
=========================

* Speaker   : Luis Correia
* Available : all days
* Length    : 45 minutes +  Q&A
* Language  : Portuguese

Description
-----------

Fueled by last year's appearance of an actual ZX Spectrum, I've managed to get my units back to working condition

In this short talk I'll explain what you need to do to your ageing hardware in order to make them work again. This is specific for the Speccy but most can be also used for C64 ans Atari ST machines.

Emulators are fun, easy and convenient but nothing like the actual feel of that crappy rubber keys

(if aprooved, it might summon actual ZX Spectrums, for science)

Speaker Bio
-----------

Legendary bicopter/tricopter builder, member of the fine One Over Zero community, mostly known as the "lobster crew"
Co-creator of OOZLabs, a closed maker group that essentially makes things and stuff.

Links
-----

* Blog: https://blog.loide.net
* Company: https://labs.oneoverzero.org
* Github: https://github.com/oozlabs / https://github.com/luisfcorreia
* Photo: https://avatars3.githubusercontent.com/u/191885?v=3&s=400

Extra Information
-----------------

This talk was a last minute shout out from my heart and it loosely relates to right to repair

Past talks @ PixelsCamp 
* https://github.com/PixelsCamp/talks/blob/master/2019/right-to-repair_luis-correia.md
* https://github.com/PixelsCamp/talks/blob/master/2016/ooz2mars-rover_luis-correia.md